### PR TITLE
Do not prevent touchEvent if keyboard is not open

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -452,7 +452,7 @@ function keyboardOnKeyDown(e) {
  * elements outside the scroll view while the keyboard is open.
  */
 function keyboardPreventDefault(e) {
-  if (e.target.tagName !== 'TEXTAREA') {
+  if (ionic.keyboard.isOpen && e.target.tagName !== 'TEXTAREA') {
     e.preventDefault();
   }
 }


### PR DESCRIPTION
[NB: No codepen is provided as the issue can not be reproduced in common Browsers. But it is easy to reproduce on Android devices and emulators]

As the JSdoc of keyboardPreventDefault() states, the purpose is to prevent native scrolling while "the keyboard is open".

The function keyboardHide(), responsible for removing the listener on "touchMove" (which use keyboardPreventDefault() as a callback) might  not be called when the keyboard is automatically closed (i.e: after submitting a form thanks to the "Go" button of the native keyboard of Android devices). As a result, the listener on "touchMove" might not be removed and keyboardPreventDefault may still be called on a different view (which does need the touchMove event... But this last will be Prevented). If the touchMove event is prevented, the following statement will be equal to false:

``` js
!e.gesture.srcEvent.defaultPrevented
```

Making the method isDraggableTarget of controller $ionicSideMenus always return **false** => the side menu won't open by "swipe".

Checking that the keyboard is open before preventing the event solves this issue.

(Note: Calling close() method of the keyboard plugin does hide the keyboard, but does not execute keyboardHide()).

I suggest a very small unit-test to accompany this fix, like:

``` js
    // (assuming that ionic.keyboard.isOpen is initially equal to "false")
    it('should not prevent event if keyboard is not open', function() {
      var touchEvent = { 
        preventDefault: jasmine.createSpy('preventDefault spy'),  
        target: {
          tagName: 'TEXTAREA'
       }
      };

      keyboardPreventDefault(touchEvent);
      expect(touchEvent.preventDefault).not.toHaveBeenCalled();
    });
```
